### PR TITLE
feat: SCRUM-39 Create client location catalog

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
 
             //maps
             implementation(libs.maps.compose)
+            implementation(libs.play.services.location)
 
         }
         commonMain.dependencies {

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/composeApp/src/androidMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
+++ b/composeApp/src/androidMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
@@ -1,0 +1,100 @@
+package com.example.seviya.UI
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.location.Geocoder
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.seviya.theme.AvatarBlueSoft
+import com.example.seviya.theme.BrandBlue
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import java.util.Locale
+
+@Composable
+actual fun CurrentLocationButton(
+    onLocationObtained: (latitude: Double, longitude: Double, province: String, canton: String, district: String) -> Unit,
+    onError: () -> Unit
+) {
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+            try {
+                @SuppressLint("MissingPermission")
+                val task = fusedClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
+                task.addOnSuccessListener { location ->
+                    if (location != null) {
+                        val geocoder = Geocoder(context, Locale("es", "CR"))
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            geocoder.getFromLocation(location.latitude, location.longitude, 1) { addresses ->
+                                val address = addresses.firstOrNull()
+                                onLocationObtained(
+                                    location.latitude,
+                                    location.longitude,
+                                    address?.adminArea ?: "",
+                                    address?.subAdminArea ?: "",
+                                    address?.locality ?: ""
+                                )
+                            }
+                        } else {
+                            @Suppress("DEPRECATION")
+                            val addresses = geocoder.getFromLocation(location.latitude, location.longitude, 1)
+                            val address = addresses?.firstOrNull()
+                            onLocationObtained(
+                                location.latitude,
+                                location.longitude,
+                                address?.adminArea ?: "",
+                                address?.subAdminArea ?: "",
+                                address?.locality ?: ""
+                            )
+                        }
+                    } else {
+                        onError()
+                    }
+                }
+                task.addOnFailureListener {
+                    onError()
+                }
+            } catch (e: SecurityException) {
+                onError()
+            }
+        } else {
+            onError()
+        }
+    }
+
+    Button(
+        onClick = { launcher.launch(Manifest.permission.ACCESS_FINE_LOCATION) },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = AvatarBlueSoft,
+            contentColor = BrandBlue
+        ),
+        shape = RoundedCornerShape(14.dp)
+    ) {
+        Text(
+            text = "Usar mi ubicación actual",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/App.kt
@@ -139,6 +139,9 @@ import com.example.shared.presentation.workerDailyAppointments.WorkerDailyAppoin
 import com.example.shared.presentation.workerDashboard.WorkerDashboardViewModel
 import com.example.shared.presentation.workerStartAppointmentOtp.WorkerStartAppointmentOtpViewModel
 import com.example.shared.presentation.workersList.WorkersListViewModel
+import com.example.shared.presentation.clientLocationCatalog.ClientLocationCatalogViewModel
+import com.example.seviya.UI.ClientLocationCatalogScreen
+import com.example.seviya.navigation.ClientLocationCatalog
 import compose.icons.TablerIcons
 import compose.icons.tablericons.Adjustments
 import compose.icons.tablericons.Briefcase
@@ -147,6 +150,7 @@ import compose.icons.tablericons.ChartBar
 import compose.icons.tablericons.Clock
 import compose.icons.tablericons.Dashboard
 import compose.icons.tablericons.Logout
+import compose.icons.tablericons.MapPin
 import compose.icons.tablericons.Message
 import compose.icons.tablericons.Photo
 import compose.icons.tablericons.Settings
@@ -214,7 +218,8 @@ fun App() {
                                 currentDestination.isRoute<ClientFavorites>() ||
                                 currentDestination.isRoute<RequestAppointment>()||
                                 currentDestination.isRoute<ClientRequests>() ||
-                                currentDestination.isRoute<ClientPaymentUpload>()
+                                currentDestination.isRoute<ClientPaymentUpload>() ||
+                                currentDestination.isRoute<ClientLocationCatalog>()
                         )
 
     val showWorkerBottomBar =
@@ -762,6 +767,15 @@ fun App() {
                         )
                     }
 
+                    composable<ClientLocationCatalog> {
+                        val viewModel: ClientLocationCatalogViewModel = koinViewModel()
+                        ClientLocationCatalogScreen(
+                            clientId = currentClientId,
+                            viewModel = viewModel,
+                            onBack = { navController.popBackStack() }
+                        )
+                    }
+
                     composable<ClientAppointmentDetail> { backStackEntry ->
                         val route = backStackEntry.toRoute<ClientAppointmentDetail>()
                         val viewModel: ClientAppointmentDetailViewModel = koinViewModel()
@@ -1271,6 +1285,16 @@ private fun clientMenuOptions(
             onClick = {
                 closeMenu()
                 navController.navigateSingleTop(ClientFavorites)
+            }
+        ),
+        MenuOption(
+            title = "Mis Ubicaciones",
+            subtitle = "Gestiona tus direcciones frecuentes",
+            icon = TablerIcons.MapPin,
+            iconColor = Color(0xFF4A9EC7),
+            onClick = {
+                closeMenu()
+                navController.navigateSingleTop(ClientLocationCatalog)
             }
         ),
         MenuOption(

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/UI/ClientLocationCatalogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/UI/ClientLocationCatalogScreen.kt
@@ -1,0 +1,674 @@
+package com.example.seviya.UI
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.seviya.theme.AppBackground
+import com.example.seviya.theme.AvatarBlueSoft
+import com.example.seviya.theme.BlueGrayText
+import com.example.seviya.theme.BorderSoft
+import com.example.seviya.theme.BrandBlue
+import com.example.seviya.theme.BrandRed
+import com.example.seviya.theme.CardSurface
+import com.example.seviya.theme.DividerSoft
+import com.example.seviya.theme.SubtitleOnBlue
+import com.example.seviya.theme.TextPrimary
+import com.example.seviya.theme.TextSecondary
+import com.example.seviya.theme.White
+import com.example.shared.domain.entity.Address
+import com.example.shared.presentation.clientLocationCatalog.ClientLocationCatalogViewModel
+import compose.icons.TablerIcons
+import compose.icons.tablericons.ArrowLeft
+import compose.icons.tablericons.Briefcase
+import compose.icons.tablericons.Pencil
+import compose.icons.tablericons.Home
+import compose.icons.tablericons.MapPin
+import compose.icons.tablericons.Trash
+import compose.icons.tablericons.X
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClientLocationCatalogScreen(
+    clientId: String,
+    viewModel: ClientLocationCatalogViewModel,
+    onBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    var showSheet by remember { mutableStateOf(false) }
+    var editingAddress by remember { mutableStateOf<Address?>(null) }
+
+    LaunchedEffect(clientId) {
+        viewModel.loadAddresses(clientId)
+    }
+
+    Scaffold(
+        containerColor = AppBackground
+    ) { innerPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                // --- Header ---
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = BrandBlue,
+                            shape = RoundedCornerShape(bottomStart = 32.dp, bottomEnd = 32.dp)
+                        )
+                        .systemBarsPadding()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 16.dp, bottom = 32.dp)
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(White.copy(alpha = 0.2f))
+                            .clickable { onBack() }
+                            .align(Alignment.CenterStart),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = TablerIcons.ArrowLeft,
+                            contentDescription = "Volver",
+                            tint = White,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                    Text(
+                        text = "Mis Ubicaciones",
+                        color = White,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+
+                // --- Content ---
+                if (uiState.isLoading) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = BrandBlue)
+                    }
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                            start = 16.dp,
+                            end = 16.dp,
+                            top = 16.dp,
+                            bottom = 100.dp
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        if (uiState.addresses.isEmpty()) {
+                            item {
+                                EmptyLocationsState()
+                            }
+                        } else {
+                            items(uiState.addresses) { address ->
+                                LocationCard(
+                                    address = address,
+                                    onEdit = {
+                                        editingAddress = address
+                                        showSheet = true
+                                    },
+                                    onDelete = {
+                                        viewModel.deleteAddress(clientId, address.id)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // --- FAB: Agregar ubicación ---
+            Button(
+                onClick = {
+                    editingAddress = null
+                    showSheet = true
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+                    .padding(bottom = 24.dp, start = 32.dp, end = 32.dp)
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .shadow(8.dp, RoundedCornerShape(16.dp)),
+                colors = ButtonDefaults.buttonColors(containerColor = BrandBlue),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(
+                    text = "+ Agregar Nueva Ubicación",
+                    color = White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+
+    // --- Bottom Sheet: Agregar / Editar ---
+    if (showSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showSheet = false },
+            sheetState = sheetState,
+            containerColor = CardSurface
+        ) {
+            AddEditLocationForm(
+                initial = editingAddress,
+                isSaving = uiState.isSaving,
+                onSave = { address ->
+                    viewModel.saveAddress(clientId, address)
+                    scope.launch { sheetState.hide() }.invokeOnCompletion {
+                        showSheet = false
+                    }
+                },
+                onCancel = {
+                    scope.launch { sheetState.hide() }.invokeOnCompletion {
+                        showSheet = false
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocationCard(
+    address: Address,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(2.dp, RoundedCornerShape(20.dp))
+            .background(CardSurface, RoundedCornerShape(20.dp))
+            .border(1.dp, BorderSoft, RoundedCornerShape(20.dp))
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Icon background
+        Box(
+            modifier = Modifier
+                .size(52.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(AvatarBlueSoft),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = if (address.alias.lowercase().contains("trabajo") ||
+                    address.alias.lowercase().contains("oficina")
+                ) TablerIcons.Briefcase else TablerIcons.Home,
+                contentDescription = null,
+                tint = BrandBlue,
+                modifier = Modifier.size(26.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = address.alias.ifBlank { "Sin nombre" },
+                color = TextPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = buildString {
+                    if (address.district.isNotBlank()) append(address.district)
+                    if (address.district.isNotBlank() && address.province.isNotBlank()) append(", ")
+                    if (address.province.isNotBlank()) append(address.province)
+                }.ifBlank { "Sin dirección" },
+                color = TextSecondary,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (address.reference.isNotBlank()) {
+                Text(
+                    text = address.reference,
+                    color = BlueGrayText,
+                    fontSize = 11.sp,
+                    fontStyle = FontStyle.Italic,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        // Edit button
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .clickable { onEdit() },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = TablerIcons.Pencil,
+                contentDescription = "Editar",
+                tint = BrandBlue,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        // Delete button
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .clickable { onDelete() },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = TablerIcons.Trash,
+                contentDescription = "Eliminar",
+                tint = BrandRed,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyLocationsState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 48.dp, start = 24.dp, end = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(AvatarBlueSoft),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = TablerIcons.MapPin,
+                contentDescription = null,
+                tint = BrandBlue,
+                modifier = Modifier.size(56.dp)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Sin ubicaciones guardadas",
+            color = TextPrimary,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center
+        )
+        Text(
+            text = "Agrega tus direcciones frecuentes para solicitar citas más rápido.",
+            color = TextSecondary,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+            lineHeight = 20.sp
+        )
+    }
+}
+
+@Composable
+private fun AddEditLocationForm(
+    initial: Address?,
+    isSaving: Boolean,
+    onSave: (Address) -> Unit,
+    onCancel: () -> Unit
+) {
+    val isEditing = initial != null
+
+    var alias by remember(initial) { mutableStateOf(initial?.alias ?: "") }
+    var province by remember(initial) { mutableStateOf(initial?.province ?: "") }
+    var district by remember(initial) { mutableStateOf(initial?.district ?: "") }
+    var canton by remember(initial) { mutableStateOf(initial?.canton ?: "") }
+    var reference by remember(initial) { mutableStateOf(initial?.reference ?: "") }
+    var latitude by remember(initial) { mutableStateOf(initial?.latitude ?: 0.0) }
+    var longitude by remember(initial) { mutableStateOf(initial?.longitude ?: 0.0) }
+    var locationLabel by remember(initial) {
+        mutableStateOf(
+            if ((initial?.latitude ?: 0.0) != 0.0) "%.5f, %.5f".format(initial!!.latitude, initial.longitude)
+            else "Sin ubicación GPS"
+        )
+    }
+
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState)
+            .imePadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Sheet handle / title row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (isEditing) "Editar Ubicación" else "Nueva Ubicación",
+                color = TextPrimary,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(AppBackground)
+                    .clickable { onCancel() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = TablerIcons.X,
+                    contentDescription = "Cerrar",
+                    tint = BlueGrayText,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Step 1: Map placeholder
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .shadow(1.dp, RoundedCornerShape(20.dp))
+                .background(CardSurface, RoundedCornerShape(20.dp))
+                .border(1.dp, BorderSoft, RoundedCornerShape(20.dp))
+                .padding(16.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(BrandBlue),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("1", color = White, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "SELECCIONAR EN MAPA",
+                    color = BrandBlue,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(AvatarBlueSoft),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        imageVector = TablerIcons.MapPin,
+                        contentDescription = null,
+                        tint = BrandBlue,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = locationLabel,
+                        color = BlueGrayText,
+                        fontSize = 11.sp,
+                        fontStyle = FontStyle.Italic
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            CurrentLocationButton(
+                onLocationObtained = { lat, lng, prov, cant, dist ->
+                    latitude = lat
+                    longitude = lng
+                    locationLabel = "%.5f, %.5f".format(lat, lng)
+                    if (prov.isNotBlank()) province = prov
+                    if (cant.isNotBlank()) canton = cant
+                    if (dist.isNotBlank()) district = dist
+                },
+                onError = {
+                    locationLabel = "No se pudo obtener la ubicación"
+                }
+            )
+        }
+
+        // Step 2: Form
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .shadow(1.dp, RoundedCornerShape(20.dp))
+                .background(CardSurface, RoundedCornerShape(20.dp))
+                .border(1.dp, BorderSoft, RoundedCornerShape(20.dp))
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(BrandBlue),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("2", color = White, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "DETALLES DE LA UBICACIÓN",
+                    color = BrandBlue,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.sp
+                )
+            }
+
+            FormField(
+                label = "NOMBRE / ALIAS",
+                value = alias,
+                onValueChange = { alias = it },
+                placeholder = "Ej. Mi Casa, Oficina, Gimnasio"
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Box(modifier = Modifier.weight(1f)) {
+                    FormField(
+                        label = "PROVINCIA",
+                        value = province,
+                        onValueChange = { province = it },
+                        placeholder = "Ej. San José"
+                    )
+                }
+                Box(modifier = Modifier.weight(1f)) {
+                    FormField(
+                        label = "CANTÓN",
+                        value = canton,
+                        onValueChange = { canton = it },
+                        placeholder = "Ej. Escazú"
+                    )
+                }
+            }
+
+            FormField(
+                label = "DISTRITO",
+                value = district,
+                onValueChange = { district = it },
+                placeholder = "Ej. San Rafael"
+            )
+
+            FormField(
+                label = "REFERENCIAS",
+                value = reference,
+                onValueChange = { reference = it },
+                placeholder = "Ej. Portón blanco frente al parque",
+                minLines = 3
+            )
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        if (latitude == 0.0 || longitude == 0.0) {
+            Text(
+                text = "Debes usar tu ubicación actual para poder guardar",
+                color = BrandRed,
+                fontSize = 12.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Button(
+            onClick = {
+                onSave(
+                    Address(
+                        id = initial?.id ?: "",
+                        alias = alias.trim(),
+                        province = province.trim(),
+                        district = district.trim(),
+                        canton = canton.trim(),
+                        reference = reference.trim(),
+                        latitude = latitude,
+                        longitude = longitude,
+                        isDefault = initial?.isDefault ?: false
+                    )
+                )
+            },
+            enabled = alias.isNotBlank() && latitude != 0.0 && longitude != 0.0 && !isSaving,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = BrandBlue),
+            shape = RoundedCornerShape(16.dp)
+        ) {
+            if (isSaving) {
+                CircularProgressIndicator(color = White, modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            } else {
+                Text(
+                    text = if (isEditing) "Actualizar Ubicación" else "Guardar Ubicación",
+                    color = White,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FormField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    minLines: Int = 1
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = label,
+            color = BlueGrayText,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.8.sp
+        )
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = {
+                Text(placeholder, color = BlueGrayText, fontSize = 13.sp)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+            maxLines = if (minLines > 1) 5 else 1,
+            shape = RoundedCornerShape(14.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = BrandBlue,
+                unfocusedBorderColor = BorderSoft,
+                focusedContainerColor = White,
+                unfocusedContainerColor = AppBackground,
+                focusedTextColor = TextPrimary,
+                unfocusedTextColor = TextPrimary
+            )
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
@@ -1,0 +1,9 @@
+package com.example.seviya.UI
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun CurrentLocationButton(
+    onLocationObtained: (latitude: Double, longitude: Double, province: String, canton: String, district: String) -> Unit,
+    onError: () -> Unit
+)

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/navigation/Routes.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/navigation/Routes.kt
@@ -58,6 +58,7 @@ data class WorkerPaymentDetail(val bookingId: String)
 data class WorkerStartAppointmentOtp(val appointmentId: String)
 
 @Serializable object ClientFavorites
+@Serializable object ClientLocationCatalog
 
 @Serializable
 data class ClientPaymentUpload(

--- a/composeApp/src/iosMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
+++ b/composeApp/src/iosMain/kotlin/com/example/seviya/UI/CurrentLocationButton.kt
@@ -1,0 +1,12 @@
+package com.example.seviya.UI
+
+import androidx.compose.runtime.Composable
+
+// TODO: iOS location implementation pending
+@Composable
+actual fun CurrentLocationButton(
+    onLocationObtained: (latitude: Double, longitude: Double, province: String, canton: String, district: String) -> Unit,
+    onError: () -> Unit
+) {
+    // No-op for iOS — implementation will be added in a future sprint
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,12 +33,14 @@ firebase-bom = "34.10.0"
 
 
 maps-compose = "4.4.1"
+play-services-location = "21.3.0"
 
 [libraries]
 
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 
 maps-compose = { group = "com.google.maps.android", name = "maps-compose", version.ref = "maps-compose" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "play-services-location" }
 
 compose-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "composeMultiplatform" }
 composeIcons-tabler = { module = "br.com.devsrsouza.compose.icons:tabler-icons", version.ref = "devsrComposeIcons" }

--- a/shared/src/commonMain/kotlin/com/example/shared/di/modules/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/di/modules/PresentationModule.kt
@@ -18,6 +18,7 @@ import com.example.shared.presentation.workerDailyAppointments.WorkerDailyAppoin
 import com.example.shared.presentation.workerDashboard.WorkerDashboardViewModel
 import com.example.shared.presentation.workerStartAppointmentOtp.WorkerStartAppointmentOtpViewModel
 import com.example.shared.presentation.workersList.WorkersListViewModel
+import com.example.shared.presentation.clientLocationCatalog.ClientLocationCatalogViewModel
 import org.koin.dsl.module
 
 val presentationModule = module {
@@ -43,4 +44,5 @@ val presentationModule = module {
     factory { WorkerRequestDetailViewModel(get(), get()) }
     factory { ClientPaymentUploadViewModel(get(), get(), get()) }
     factory { WorkerDailyAppointmentsViewModel(get()) }
+    factory { ClientLocationCatalogViewModel(get()) }
 }

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/clientLocationCatalog/ClientLocationCatalogUiState.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/clientLocationCatalog/ClientLocationCatalogUiState.kt
@@ -1,0 +1,11 @@
+package com.example.shared.presentation.clientLocationCatalog
+
+import com.example.shared.domain.entity.Address
+
+data class ClientLocationCatalogUiState(
+    val isLoading: Boolean = false,
+    val addresses: List<Address> = emptyList(),
+    val isSaving: Boolean = false,
+    val isDeleting: Boolean = false,
+    val errorMessage: String? = null
+)

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/clientLocationCatalog/ClientLocationCatalogViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/clientLocationCatalog/ClientLocationCatalogViewModel.kt
@@ -1,0 +1,79 @@
+package com.example.shared.presentation.clientLocationCatalog
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.shared.data.repository.Address.IAddressRepository
+import com.example.shared.domain.entity.Address
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ClientLocationCatalogViewModel(
+    private val repository: IAddressRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ClientLocationCatalogUiState())
+    val uiState: StateFlow<ClientLocationCatalogUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    fun loadAddresses(userId: String) {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
+            try {
+                repository.getAddressesByUser(userId).collect { addresses ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        addresses = addresses.sortedWith(
+                            compareByDescending<Address> { it.isDefault }
+                                .thenBy { it.alias.lowercase() }
+                        ),
+                        errorMessage = null
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    errorMessage = e.message ?: "Error cargando ubicaciones"
+                )
+            }
+        }
+    }
+
+    fun saveAddress(userId: String, address: Address) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, errorMessage = null)
+            try {
+                if (address.id.isBlank()) {
+                    repository.createAddress(userId, address)
+                } else {
+                    repository.updateAddress(userId, address)
+                }
+                _uiState.value = _uiState.value.copy(isSaving = false)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSaving = false,
+                    errorMessage = e.message ?: "Error guardando ubicación"
+                )
+            }
+        }
+    }
+
+    fun deleteAddress(userId: String, addressId: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isDeleting = true, errorMessage = null)
+            try {
+                repository.deleteAddress(userId, addressId)
+                _uiState.value = _uiState.value.copy(isDeleting = false)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isDeleting = false,
+                    errorMessage = e.message ?: "Error eliminando ubicación"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
  Description:

  What does this PR do?

  Implements the client's saved locations catalog (SCRUM-39), allowing users to manage frequent addresses to use when booking appointments.

  Changes included

  - New "My Locations" screen accessible from the client menu
  - Add, edit and delete saved locations
  - Auto-fill fields (province, canton, district) via reverse geocoding when GPS location is obtained
  - "Use my current location" button using FusedLocationProviderClient (Android) — iOS pending for future sprint
  - Validation: cannot save a location without GPS coordinates
  - ViewModel and UiState in shared layer (ClientLocationCatalogViewModel)
  - ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION permissions added to AndroidManifest
  - play-services-location 21.3.0 dependency added

  Base → Target

  CreateCatalogUbicationClient → dev

  Definition of Done

  - "My Locations" section exists in the client menu
  - Client can create and save locations in Firebase
  - Client can edit and delete saved locations
  - When booking an appointment, location is selected from the catalog (already implemented in RequestAppointmentScreen)
  - If no locations are saved, a message and add option are displayed
  - iOS location — pending future sprint