### PR TITLE
feat(SCRUM-48): implement worker availability configuration screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -52,7 +51,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -65,6 +63,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -80,13 +79,11 @@ import com.example.seviya.core.designsystem.theme.SoftBlueSurface
 import com.example.seviya.core.designsystem.theme.TextBluePrimary
 import com.example.seviya.core.designsystem.theme.TextSecondary
 import com.example.seviya.core.designsystem.theme.White
-import com.example.shared.presentation.workerAvailability.ExceptionUiItem
+import com.example.shared.presentation.workerAvailability.DayUiItem
 import com.example.shared.presentation.workerAvailability.WorkerAvailabilityUiState
 import com.example.shared.presentation.workerAvailability.WorkerAvailabilityViewModel
 import compose.icons.TablerIcons
 import compose.icons.tablericons.ArrowLeft
-import compose.icons.tablericons.Calendar
-import compose.icons.tablericons.CalendarOff
 import compose.icons.tablericons.Check
 import compose.icons.tablericons.Clock
 import compose.icons.tablericons.Plus
@@ -104,15 +101,9 @@ fun WorkerAvailabilityScreen(workerId: String, onBack: () -> Unit) {
         uiState = uiState,
         onBack = onBack,
         onToggleDay = { viewModel.toggleDay(it) },
-        onUpdateDayTime = { key, s, e -> viewModel.updateDayTime(key, s, e) },
-        onOpenExceptionDialog = { viewModel.openExceptionDialog() },
-        onCloseExceptionDialog = { viewModel.closeExceptionDialog() },
-        onUpdatePendingDate = { viewModel.updatePendingDate(it) },
-        onUpdatePendingType = { viewModel.updatePendingType(it) },
-        onUpdatePendingStart = { viewModel.updatePendingStart(it) },
-        onUpdatePendingEnd = { viewModel.updatePendingEnd(it) },
-        onConfirmException = { viewModel.confirmException(workerId) },
-        onDeleteException = { viewModel.deleteException(workerId, it) },
+        onAddTimeBlock = { viewModel.addTimeBlock(it) },
+        onRemoveTimeBlock = { day, idx -> viewModel.removeTimeBlock(day, idx) },
+        onUpdateTimeBlock = { day, idx, s, e -> viewModel.updateTimeBlock(day, idx, s, e) },
         onSave = { viewModel.save(workerId) },
         onClearSaveSuccess = { viewModel.clearSaveSuccess() },
         onClearError = { viewModel.clearError() },
@@ -124,15 +115,9 @@ private fun WorkerAvailabilityContent(
     uiState: WorkerAvailabilityUiState,
     onBack: () -> Unit,
     onToggleDay: (String) -> Unit,
-    onUpdateDayTime: (String, String, String) -> Unit,
-    onOpenExceptionDialog: () -> Unit,
-    onCloseExceptionDialog: () -> Unit,
-    onUpdatePendingDate: (String) -> Unit,
-    onUpdatePendingType: (Boolean) -> Unit,
-    onUpdatePendingStart: (String) -> Unit,
-    onUpdatePendingEnd: (String) -> Unit,
-    onConfirmException: () -> Unit,
-    onDeleteException: (String) -> Unit,
+    onAddTimeBlock: (String) -> Unit,
+    onRemoveTimeBlock: (String, Int) -> Unit,
+    onUpdateTimeBlock: (String, Int, String, String) -> Unit,
     onSave: () -> Unit,
     onClearSaveSuccess: () -> Unit,
     onClearError: () -> Unit,
@@ -141,7 +126,7 @@ private fun WorkerAvailabilityContent(
 
     LaunchedEffect(uiState.saveSuccess) {
         if (uiState.saveSuccess) {
-            snackbarHostState.showSnackbar("Disponibilidad guardada correctamente")
+            snackbarHostState.showSnackbar("Availability saved successfully")
             onClearSaveSuccess()
         }
     }
@@ -151,21 +136,6 @@ private fun WorkerAvailabilityContent(
             snackbarHostState.showSnackbar(it)
             onClearError()
         }
-    }
-
-    if (uiState.showExceptionDialog) {
-        AddExceptionDialog(
-            pendingDate = uiState.pendingDate,
-            pendingIsUnavailable = uiState.pendingIsUnavailable,
-            pendingStart = uiState.pendingStart,
-            pendingEnd = uiState.pendingEnd,
-            onDateChange = onUpdatePendingDate,
-            onTypeChange = onUpdatePendingType,
-            onStartChange = onUpdatePendingStart,
-            onEndChange = onUpdatePendingEnd,
-            onConfirm = onConfirmException,
-            onDismiss = onCloseExceptionDialog,
-        )
     }
 
     Scaffold(
@@ -186,7 +156,10 @@ private fun WorkerAvailabilityContent(
             AvailabilityHeader(onBack = onBack)
 
             if (uiState.isLoading) {
-                Box(Modifier.fillMaxWidth().padding(48.dp), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
                     CircularProgressIndicator(color = BrandBlue)
                 }
             } else {
@@ -195,105 +168,44 @@ private fun WorkerAvailabilityContent(
                         .fillMaxWidth()
                         .padding(horizontal = 20.dp)
                         .padding(top = 24.dp, bottom = 100.dp),
-                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    // Reglas semanales
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = "Reglas semanales",
-                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                color = TextBluePrimary,
-                            )
-                            Text(
-                                text = "HORARIO BASE",
-                                style = MaterialTheme.typography.labelSmall.copy(
-                                    fontWeight = FontWeight.Bold,
-                                    letterSpacing = 1.sp,
-                                ),
-                                color = BrandBlue,
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(SoftBlueSurface)
-                                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                            )
-                        }
-
-                        uiState.days.forEach { day ->
-                            DayCard(
-                                label = day.label,
-                                enabled = day.enabled,
-                                startTime = day.startTime,
-                                endTime = day.endTime,
-                                onToggle = { onToggleDay(day.dayKey) },
-                                onStartChange = { onUpdateDayTime(day.dayKey, it, day.endTime) },
-                                onEndChange = { onUpdateDayTime(day.dayKey, day.startTime, it) },
-                            )
-                        }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "Weekly schedule",
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                            color = TextBluePrimary,
+                        )
+                        Text(
+                            text = "BASE HOURS",
+                            style = MaterialTheme.typography.labelSmall.copy(
+                                fontWeight = FontWeight.Bold,
+                                letterSpacing = 1.sp,
+                            ),
+                            color = BrandBlue,
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(SoftBlueSurface)
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
+                        )
                     }
 
-                    // Excepciones
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                text = "Excepciones",
-                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                color = TextBluePrimary,
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .clickable { onOpenExceptionDialog() }
-                                    .background(SoftBlueSurface)
-                                    .padding(horizontal = 10.dp, vertical = 6.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            ) {
-                                Icon(
-                                    imageVector = TablerIcons.Plus,
-                                    contentDescription = null,
-                                    tint = BrandBlue,
-                                    modifier = Modifier.size(14.dp),
-                                )
-                                Text(
-                                    text = "AGREGAR",
-                                    style = MaterialTheme.typography.labelSmall.copy(
-                                        fontWeight = FontWeight.Bold,
-                                        letterSpacing = 1.sp,
-                                    ),
-                                    color = BrandBlue,
-                                )
-                            }
-                        }
-
-                        if (uiState.exceptions.isEmpty()) {
-                            Text(
-                                text = "Sin excepciones registradas",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = InactiveSoft,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 12.dp),
-                            )
-                        } else {
-                            uiState.exceptions.forEach { exc ->
-                                ExceptionCard(
-                                    exception = exc,
-                                    onDelete = { onDeleteException(exc.date) },
-                                )
-                            }
-                        }
+                    uiState.days.forEach { day ->
+                        DayCard(
+                            day = day,
+                            onToggle = { onToggleDay(day.dayKey) },
+                            onAddTimeBlock = { onAddTimeBlock(day.dayKey) },
+                            onRemoveTimeBlock = { idx -> onRemoveTimeBlock(day.dayKey, idx) },
+                            onUpdateTimeBlock = { idx, s, e -> onUpdateTimeBlock(day.dayKey, idx, s, e) },
+                        )
                     }
 
-                    // Guardar
+                    Spacer(Modifier.height(8.dp))
+
                     Button(
                         onClick = onSave,
                         enabled = !uiState.isSaving,
@@ -315,7 +227,7 @@ private fun WorkerAvailabilityContent(
                             )
                         } else {
                             Text(
-                                "Guardar cambios",
+                                "Save changes",
                                 style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                             )
                             Spacer(Modifier.width(8.dp))
@@ -334,20 +246,20 @@ private fun WorkerAvailabilityContent(
 
 @Composable
 private fun DayCard(
-    label: String,
-    enabled: Boolean,
-    startTime: String,
-    endTime: String,
+    day: DayUiItem,
     onToggle: () -> Unit,
-    onStartChange: (String) -> Unit,
-    onEndChange: (String) -> Unit,
+    onAddTimeBlock: () -> Unit,
+    onRemoveTimeBlock: (Int) -> Unit,
+    onUpdateTimeBlock: (Int, String, String) -> Unit,
 ) {
     Card(
         shape = RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
-            containerColor = if (enabled) White else White.copy(alpha = 0.6f)
+            containerColor = if (day.enabled) White else White.copy(alpha = 0.6f),
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = if (enabled) 2.dp else 0.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = if (day.enabled) 2.dp else 0.dp,
+        ),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -357,12 +269,12 @@ private fun DayCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = label,
+                    text = day.label,
                     style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-                    color = if (enabled) TextBluePrimary else InactiveSoft,
+                    color = if (day.enabled) TextBluePrimary else InactiveSoft,
                 )
                 Switch(
-                    checked = enabled,
+                    checked = day.enabled,
                     onCheckedChange = { onToggle() },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = White,
@@ -373,45 +285,111 @@ private fun DayCard(
                 )
             }
 
+            // Time blocks when enabled
             AnimatedVisibility(
-                visible = enabled,
+                visible = day.enabled,
                 enter = expandVertically() + fadeIn(),
                 exit = shrinkVertically() + fadeOut(),
             ) {
-                Column {
-                    Spacer(Modifier.height(12.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        TimeField(
-                            modifier = Modifier.weight(1f),
-                            label = "Desde",
-                            value = startTime,
-                            onValueChange = onStartChange,
+                Column(
+                    modifier = Modifier.padding(top = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    day.timeBlocks.forEachIndexed { index, block ->
+                        TimeBlockRow(
+                            start = block.start,
+                            end = block.end,
+                            canRemove = day.timeBlocks.size > 1,
+                            onStartChange = { onUpdateTimeBlock(index, it, block.end) },
+                            onEndChange = { onUpdateTimeBlock(index, block.start, it) },
+                            onRemove = { onRemoveTimeBlock(index) },
                         )
-                        TimeField(
-                            modifier = Modifier.weight(1f),
-                            label = "Hasta",
-                            value = endTime,
-                            onValueChange = onEndChange,
+                    }
+
+                    // Add time range button
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .clickable { onAddTimeBlock() }
+                            .background(SoftBlueSurface)
+                            .padding(vertical = 10.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = TablerIcons.Plus,
+                            contentDescription = null,
+                            tint = BrandBlue,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Spacer(Modifier.width(6.dp))
+                        Text(
+                            text = "Add time range",
+                            style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                            color = BrandBlue,
                         )
                     }
                 }
             }
 
+            // Not available label when disabled
             AnimatedVisibility(
-                visible = !enabled,
+                visible = !day.enabled,
                 enter = fadeIn(),
                 exit = fadeOut(),
             ) {
                 Text(
-                    text = "No disponible",
-                    style = MaterialTheme.typography.bodySmall.copy(fontStyle = androidx.compose.ui.text.font.FontStyle.Italic),
+                    text = "Not available",
+                    style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
                     color = InactiveSoft,
                     modifier = Modifier.padding(top = 4.dp),
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun TimeBlockRow(
+    start: String,
+    end: String,
+    canRemove: Boolean,
+    onStartChange: (String) -> Unit,
+    onEndChange: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TimeField(
+            modifier = Modifier.weight(1f),
+            label = "From",
+            value = start,
+            onValueChange = onStartChange,
+        )
+        TimeField(
+            modifier = Modifier.weight(1f),
+            label = "To",
+            value = end,
+            onValueChange = onEndChange,
+        )
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(if (canRemove) ErrorRedSoft else BorderSoft)
+                .clickable(enabled = canRemove) { onRemove() },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = TablerIcons.Trash,
+                contentDescription = "Remove",
+                tint = if (canRemove) ErrorText else InactiveSoft,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }
@@ -473,223 +451,6 @@ private fun TimeField(
 }
 
 @Composable
-private fun ExceptionCard(
-    exception: ExceptionUiItem,
-    onDelete: () -> Unit,
-) {
-    Card(
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = White),
-        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            modifier = Modifier.padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(if (exception.isUnavailable) ErrorRedSoft else SoftBlueSurface),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = if (exception.isUnavailable) TablerIcons.CalendarOff else TablerIcons.Calendar,
-                    contentDescription = null,
-                    tint = if (exception.isUnavailable) ErrorText else BrandBlue,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
-
-            Spacer(Modifier.width(12.dp))
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = exception.displayDate,
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                    color = TextBluePrimary,
-                )
-                Text(
-                    text = if (exception.isUnavailable) "No disponible"
-                    else "${exception.startTime} – ${exception.endTime}",
-                    style = MaterialTheme.typography.labelSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.5.sp,
-                    ),
-                    color = if (exception.isUnavailable) ErrorText else BrandBlue,
-                )
-            }
-
-            Box(
-                modifier = Modifier
-                    .size(36.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable { onDelete() }
-                    .background(ErrorRedSoft),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = TablerIcons.Trash,
-                    contentDescription = "Eliminar",
-                    tint = ErrorText,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun AddExceptionDialog(
-    pendingDate: String,
-    pendingIsUnavailable: Boolean,
-    pendingStart: String,
-    pendingEnd: String,
-    onDateChange: (String) -> Unit,
-    onTypeChange: (Boolean) -> Unit,
-    onStartChange: (String) -> Unit,
-    onEndChange: (String) -> Unit,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        containerColor = White,
-        shape = RoundedCornerShape(20.dp),
-        title = {
-            Text(
-                "Nueva excepción",
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                color = TextBluePrimary,
-            )
-        },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                // Fecha
-                Column {
-                    Text(
-                        "FECHA (AAAA-MM-DD)",
-                        style = MaterialTheme.typography.labelSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 1.sp,
-                        ),
-                        color = TextSecondary,
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    OutlinedTextField(
-                        value = pendingDate,
-                        onValueChange = onDateChange,
-                        placeholder = {
-                            Text("2025-10-15", color = InactiveSoft)
-                        },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp),
-                        colors = OutlinedTextFieldDefaults.colors(
-                            focusedBorderColor = BrandBlue,
-                            unfocusedBorderColor = BorderSoft,
-                            cursorColor = BrandBlue,
-                        ),
-                    )
-                }
-
-                // Tipo
-                Column {
-                    Text(
-                        "TIPO",
-                        style = MaterialTheme.typography.labelSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 1.sp,
-                        ),
-                        color = TextSecondary,
-                    )
-                    Spacer(Modifier.height(6.dp))
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        TypeChip(
-                            modifier = Modifier.weight(1f),
-                            label = "No disponible",
-                            selected = pendingIsUnavailable,
-                            selectedColor = BrandRed,
-                            onClick = { onTypeChange(true) },
-                        )
-                        TypeChip(
-                            modifier = Modifier.weight(1f),
-                            label = "Horario especial",
-                            selected = !pendingIsUnavailable,
-                            selectedColor = BrandBlue,
-                            onClick = { onTypeChange(false) },
-                        )
-                    }
-                }
-
-                // Horas (solo si horario especial)
-                AnimatedVisibility(visible = !pendingIsUnavailable) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        TimeField(
-                            modifier = Modifier.weight(1f),
-                            label = "Desde",
-                            value = pendingStart,
-                            onValueChange = onStartChange,
-                        )
-                        TimeField(
-                            modifier = Modifier.weight(1f),
-                            label = "Hasta",
-                            value = pendingEnd,
-                            onValueChange = onEndChange,
-                        )
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = onConfirm,
-                enabled = pendingDate.isNotBlank(),
-                shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = BrandBlue),
-            ) {
-                Text("Agregar", color = White, fontWeight = FontWeight.Bold)
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancelar", color = TextSecondary)
-            }
-        },
-    )
-}
-
-@Composable
-private fun TypeChip(
-    modifier: Modifier = Modifier,
-    label: String,
-    selected: Boolean,
-    selectedColor: Color,
-    onClick: () -> Unit,
-) {
-    Box(
-        modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
-            .border(
-                width = 1.5.dp,
-                color = if (selected) selectedColor else BorderSoft,
-                shape = RoundedCornerShape(10.dp),
-            )
-            .background(if (selected) selectedColor.copy(alpha = 0.08f) else White)
-            .clickable { onClick() }
-            .padding(vertical = 10.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
-            color = if (selected) selectedColor else InactiveSoft,
-        )
-    }
-}
-
-@Composable
 private fun AvailabilityHeader(onBack: () -> Unit) {
     val infiniteTransition = rememberInfiniteTransition(label = "availability_header")
 
@@ -731,16 +492,12 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
                 .clip(RoundedCornerShape(bottomStart = 26.dp, bottomEnd = 26.dp))
                 .background(BrandBlue)
         ) {
-            // Shimmer
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
                     .width(140.dp)
                     .offset(x = shimmerOffset.dp)
-                    .graphicsLayer {
-                        rotationZ = -18f
-                        alpha = 0.16f
-                    }
+                    .graphicsLayer { rotationZ = -18f; alpha = 0.16f }
                     .background(
                         Brush.linearGradient(
                             colors = listOf(
@@ -752,7 +509,6 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
                     )
             )
 
-            // Back + Logo
             Row(
                 modifier = Modifier
                     .align(Alignment.TopStart)
@@ -760,11 +516,7 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
                     .graphicsLayer { scaleX = badgeScale; scaleY = badgeScale }
                     .clip(RoundedCornerShape(999.dp))
                     .background(White.copy(alpha = 0.14f))
-                    .border(
-                        width = 1.dp,
-                        color = White.copy(alpha = 0.16f),
-                        shape = RoundedCornerShape(999.dp),
-                    )
+                    .border(1.dp, White.copy(alpha = 0.16f), RoundedCornerShape(999.dp))
                     .padding(horizontal = 12.dp, vertical = 9.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -779,7 +531,7 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
                 ) {
                     Icon(
                         imageVector = TablerIcons.ArrowLeft,
-                        contentDescription = "Volver",
+                        contentDescription = "Back",
                         tint = White,
                         modifier = Modifier.size(16.dp),
                     )
@@ -790,19 +542,14 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
                 }
             }
 
-            // Badge derecho
             Text(
-                text = "DISPONIBILIDAD",
+                text = "AVAILABILITY",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(end = 20.dp, top = 42.dp)
                     .clip(RoundedCornerShape(999.dp))
                     .background(White.copy(alpha = 0.14f))
-                    .border(
-                        width = 1.dp,
-                        color = White.copy(alpha = 0.16f),
-                        shape = RoundedCornerShape(999.dp),
-                    )
+                    .border(1.dp, White.copy(alpha = 0.16f), RoundedCornerShape(999.dp))
                     .padding(horizontal = 16.dp, vertical = 10.dp),
                 color = White,
                 fontSize = 14.sp,

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
@@ -126,7 +126,7 @@ private fun WorkerAvailabilityContent(
 
     LaunchedEffect(uiState.saveSuccess) {
         if (uiState.saveSuccess) {
-            snackbarHostState.showSnackbar("Availability saved successfully")
+            snackbarHostState.showSnackbar("Disponibilidad guardada correctamente")
             onClearSaveSuccess()
         }
     }
@@ -176,12 +176,12 @@ private fun WorkerAvailabilityContent(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = "Weekly schedule",
+                            text = "Horario semanal",
                             style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                             color = TextBluePrimary,
                         )
                         Text(
-                            text = "BASE HOURS",
+                            text = "HORARIO BASE",
                             style = MaterialTheme.typography.labelSmall.copy(
                                 fontWeight = FontWeight.Bold,
                                 letterSpacing = 1.sp,
@@ -227,7 +227,7 @@ private fun WorkerAvailabilityContent(
                             )
                         } else {
                             Text(
-                                "Save changes",
+                                "Guardar cambios",
                                 style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                             )
                             Spacer(Modifier.width(8.dp))
@@ -325,7 +325,7 @@ private fun DayCard(
                         )
                         Spacer(Modifier.width(6.dp))
                         Text(
-                            text = "Add time range",
+                            text = "Agregar rango de hora",
                             style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
                             color = BrandBlue,
                         )
@@ -340,7 +340,7 @@ private fun DayCard(
                 exit = fadeOut(),
             ) {
                 Text(
-                    text = "Not available",
+                    text = "No disponible",
                     style = MaterialTheme.typography.bodySmall.copy(fontStyle = FontStyle.Italic),
                     color = InactiveSoft,
                     modifier = Modifier.padding(top = 4.dp),
@@ -366,13 +366,13 @@ private fun TimeBlockRow(
     ) {
         TimeField(
             modifier = Modifier.weight(1f),
-            label = "From",
+            label = "Desde",
             value = start,
             onValueChange = onStartChange,
         )
         TimeField(
             modifier = Modifier.weight(1f),
-            label = "To",
+            label = "Hasta",
             value = end,
             onValueChange = onEndChange,
         )
@@ -543,7 +543,7 @@ private fun AvailabilityHeader(onBack: () -> Unit) {
             }
 
             Text(
-                text = "AVAILABILITY",
+                text = "DISPONIBILIDAD",
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(end = 20.dp, top = 42.dp)

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/WorkerAvailabilityScreen.kt
@@ -1,0 +1,813 @@
+package com.example.seviya.feature.worker
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.seviya.core.designsystem.theme.AppBackgroundAlt
+import com.example.seviya.core.designsystem.theme.BorderSoft
+import com.example.seviya.core.designsystem.theme.BrandBlue
+import com.example.seviya.core.designsystem.theme.BrandRed
+import com.example.seviya.core.designsystem.theme.ErrorRedSoft
+import com.example.seviya.core.designsystem.theme.ErrorText
+import com.example.seviya.core.designsystem.theme.InactiveSoft
+import com.example.seviya.core.designsystem.theme.SoftBlueSurface
+import com.example.seviya.core.designsystem.theme.TextBluePrimary
+import com.example.seviya.core.designsystem.theme.TextSecondary
+import com.example.seviya.core.designsystem.theme.White
+import com.example.shared.presentation.workerAvailability.ExceptionUiItem
+import com.example.shared.presentation.workerAvailability.WorkerAvailabilityUiState
+import com.example.shared.presentation.workerAvailability.WorkerAvailabilityViewModel
+import compose.icons.TablerIcons
+import compose.icons.tablericons.ArrowLeft
+import compose.icons.tablericons.Calendar
+import compose.icons.tablericons.CalendarOff
+import compose.icons.tablericons.Check
+import compose.icons.tablericons.Clock
+import compose.icons.tablericons.Plus
+import compose.icons.tablericons.Trash
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun WorkerAvailabilityScreen(workerId: String, onBack: () -> Unit) {
+    val viewModel: WorkerAvailabilityViewModel = koinViewModel()
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(workerId) { viewModel.loadData(workerId) }
+
+    WorkerAvailabilityContent(
+        uiState = uiState,
+        onBack = onBack,
+        onToggleDay = { viewModel.toggleDay(it) },
+        onUpdateDayTime = { key, s, e -> viewModel.updateDayTime(key, s, e) },
+        onOpenExceptionDialog = { viewModel.openExceptionDialog() },
+        onCloseExceptionDialog = { viewModel.closeExceptionDialog() },
+        onUpdatePendingDate = { viewModel.updatePendingDate(it) },
+        onUpdatePendingType = { viewModel.updatePendingType(it) },
+        onUpdatePendingStart = { viewModel.updatePendingStart(it) },
+        onUpdatePendingEnd = { viewModel.updatePendingEnd(it) },
+        onConfirmException = { viewModel.confirmException(workerId) },
+        onDeleteException = { viewModel.deleteException(workerId, it) },
+        onSave = { viewModel.save(workerId) },
+        onClearSaveSuccess = { viewModel.clearSaveSuccess() },
+        onClearError = { viewModel.clearError() },
+    )
+}
+
+@Composable
+private fun WorkerAvailabilityContent(
+    uiState: WorkerAvailabilityUiState,
+    onBack: () -> Unit,
+    onToggleDay: (String) -> Unit,
+    onUpdateDayTime: (String, String, String) -> Unit,
+    onOpenExceptionDialog: () -> Unit,
+    onCloseExceptionDialog: () -> Unit,
+    onUpdatePendingDate: (String) -> Unit,
+    onUpdatePendingType: (Boolean) -> Unit,
+    onUpdatePendingStart: (String) -> Unit,
+    onUpdatePendingEnd: (String) -> Unit,
+    onConfirmException: () -> Unit,
+    onDeleteException: (String) -> Unit,
+    onSave: () -> Unit,
+    onClearSaveSuccess: () -> Unit,
+    onClearError: () -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.saveSuccess) {
+        if (uiState.saveSuccess) {
+            snackbarHostState.showSnackbar("Disponibilidad guardada correctamente")
+            onClearSaveSuccess()
+        }
+    }
+
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            onClearError()
+        }
+    }
+
+    if (uiState.showExceptionDialog) {
+        AddExceptionDialog(
+            pendingDate = uiState.pendingDate,
+            pendingIsUnavailable = uiState.pendingIsUnavailable,
+            pendingStart = uiState.pendingStart,
+            pendingEnd = uiState.pendingEnd,
+            onDateChange = onUpdatePendingDate,
+            onTypeChange = onUpdatePendingType,
+            onStartChange = onUpdatePendingStart,
+            onEndChange = onUpdatePendingEnd,
+            onConfirm = onConfirmException,
+            onDismiss = onCloseExceptionDialog,
+        )
+    }
+
+    Scaffold(
+        containerColor = AppBackgroundAlt,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) { data ->
+                Snackbar(snackbarData = data, containerColor = BrandBlue, contentColor = White)
+            }
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            AvailabilityHeader(onBack = onBack)
+
+            if (uiState.isLoading) {
+                Box(Modifier.fillMaxWidth().padding(48.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = BrandBlue)
+                }
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp)
+                        .padding(top = 24.dp, bottom = 100.dp),
+                    verticalArrangement = Arrangement.spacedBy(24.dp),
+                ) {
+                    // Reglas semanales
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Reglas semanales",
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                color = TextBluePrimary,
+                            )
+                            Text(
+                                text = "HORARIO BASE",
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    letterSpacing = 1.sp,
+                                ),
+                                color = BrandBlue,
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .background(SoftBlueSurface)
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                            )
+                        }
+
+                        uiState.days.forEach { day ->
+                            DayCard(
+                                label = day.label,
+                                enabled = day.enabled,
+                                startTime = day.startTime,
+                                endTime = day.endTime,
+                                onToggle = { onToggleDay(day.dayKey) },
+                                onStartChange = { onUpdateDayTime(day.dayKey, it, day.endTime) },
+                                onEndChange = { onUpdateDayTime(day.dayKey, day.startTime, it) },
+                            )
+                        }
+                    }
+
+                    // Excepciones
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = "Excepciones",
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                color = TextBluePrimary,
+                            )
+                            Row(
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .clickable { onOpenExceptionDialog() }
+                                    .background(SoftBlueSurface)
+                                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                Icon(
+                                    imageVector = TablerIcons.Plus,
+                                    contentDescription = null,
+                                    tint = BrandBlue,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                                Text(
+                                    text = "AGREGAR",
+                                    style = MaterialTheme.typography.labelSmall.copy(
+                                        fontWeight = FontWeight.Bold,
+                                        letterSpacing = 1.sp,
+                                    ),
+                                    color = BrandBlue,
+                                )
+                            }
+                        }
+
+                        if (uiState.exceptions.isEmpty()) {
+                            Text(
+                                text = "Sin excepciones registradas",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = InactiveSoft,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 12.dp),
+                            )
+                        } else {
+                            uiState.exceptions.forEach { exc ->
+                                ExceptionCard(
+                                    exception = exc,
+                                    onDelete = { onDeleteException(exc.date) },
+                                )
+                            }
+                        }
+                    }
+
+                    // Guardar
+                    Button(
+                        onClick = onSave,
+                        enabled = !uiState.isSaving,
+                        modifier = Modifier.fillMaxWidth().height(54.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = BrandBlue,
+                            disabledContainerColor = InactiveSoft.copy(alpha = 0.35f),
+                            contentColor = White,
+                            disabledContentColor = White.copy(alpha = 0.75f),
+                        ),
+                        elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
+                    ) {
+                        if (uiState.isSaving) {
+                            CircularProgressIndicator(
+                                color = White,
+                                strokeWidth = 2.dp,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        } else {
+                            Text(
+                                "Guardar cambios",
+                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Icon(
+                                imageVector = TablerIcons.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DayCard(
+    label: String,
+    enabled: Boolean,
+    startTime: String,
+    endTime: String,
+    onToggle: () -> Unit,
+    onStartChange: (String) -> Unit,
+    onEndChange: (String) -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (enabled) White else White.copy(alpha = 0.6f)
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (enabled) 2.dp else 0.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+                    color = if (enabled) TextBluePrimary else InactiveSoft,
+                )
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = { onToggle() },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = White,
+                        checkedTrackColor = BrandBlue,
+                        uncheckedThumbColor = White,
+                        uncheckedTrackColor = BorderSoft,
+                    ),
+                )
+            }
+
+            AnimatedVisibility(
+                visible = enabled,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                Column {
+                    Spacer(Modifier.height(12.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        TimeField(
+                            modifier = Modifier.weight(1f),
+                            label = "Desde",
+                            value = startTime,
+                            onValueChange = onStartChange,
+                        )
+                        TimeField(
+                            modifier = Modifier.weight(1f),
+                            label = "Hasta",
+                            value = endTime,
+                            onValueChange = onEndChange,
+                        )
+                    }
+                }
+            }
+
+            AnimatedVisibility(
+                visible = !enabled,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Text(
+                    text = "No disponible",
+                    style = MaterialTheme.typography.bodySmall.copy(fontStyle = androidx.compose.ui.text.font.FontStyle.Italic),
+                    color = InactiveSoft,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimeField(
+    modifier: Modifier = Modifier,
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.sp,
+            ),
+            color = TextSecondary,
+        )
+        Spacer(Modifier.height(4.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = { raw ->
+                val digits = raw.filter { it.isDigit() }
+                val formatted = when {
+                    digits.length >= 4 -> "${digits.take(2)}:${digits.drop(2).take(2)}"
+                    digits.length >= 2 -> "${digits.take(2)}:${digits.drop(2)}"
+                    else -> digits
+                }
+                onValueChange(formatted)
+            },
+            placeholder = {
+                Text("HH:MM", style = MaterialTheme.typography.bodyMedium, color = InactiveSoft)
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = TablerIcons.Clock,
+                    contentDescription = null,
+                    tint = BrandBlue,
+                    modifier = Modifier.size(18.dp),
+                )
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+            shape = RoundedCornerShape(12.dp),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                fontWeight = FontWeight.Bold,
+                color = BrandBlue,
+            ),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = BrandBlue,
+                unfocusedBorderColor = BorderSoft,
+                cursorColor = BrandBlue,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun ExceptionCard(
+    exception: ExceptionUiItem,
+    onDelete: () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (exception.isUnavailable) ErrorRedSoft else SoftBlueSurface),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = if (exception.isUnavailable) TablerIcons.CalendarOff else TablerIcons.Calendar,
+                    contentDescription = null,
+                    tint = if (exception.isUnavailable) ErrorText else BrandBlue,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = exception.displayDate,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                    color = TextBluePrimary,
+                )
+                Text(
+                    text = if (exception.isUnavailable) "No disponible"
+                    else "${exception.startTime} – ${exception.endTime}",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.5.sp,
+                    ),
+                    color = if (exception.isUnavailable) ErrorText else BrandBlue,
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable { onDelete() }
+                    .background(ErrorRedSoft),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = TablerIcons.Trash,
+                    contentDescription = "Eliminar",
+                    tint = ErrorText,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddExceptionDialog(
+    pendingDate: String,
+    pendingIsUnavailable: Boolean,
+    pendingStart: String,
+    pendingEnd: String,
+    onDateChange: (String) -> Unit,
+    onTypeChange: (Boolean) -> Unit,
+    onStartChange: (String) -> Unit,
+    onEndChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = White,
+        shape = RoundedCornerShape(20.dp),
+        title = {
+            Text(
+                "Nueva excepción",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                color = TextBluePrimary,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                // Fecha
+                Column {
+                    Text(
+                        "FECHA (AAAA-MM-DD)",
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 1.sp,
+                        ),
+                        color = TextSecondary,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    OutlinedTextField(
+                        value = pendingDate,
+                        onValueChange = onDateChange,
+                        placeholder = {
+                            Text("2025-10-15", color = InactiveSoft)
+                        },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = BrandBlue,
+                            unfocusedBorderColor = BorderSoft,
+                            cursorColor = BrandBlue,
+                        ),
+                    )
+                }
+
+                // Tipo
+                Column {
+                    Text(
+                        "TIPO",
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 1.sp,
+                        ),
+                        color = TextSecondary,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        TypeChip(
+                            modifier = Modifier.weight(1f),
+                            label = "No disponible",
+                            selected = pendingIsUnavailable,
+                            selectedColor = BrandRed,
+                            onClick = { onTypeChange(true) },
+                        )
+                        TypeChip(
+                            modifier = Modifier.weight(1f),
+                            label = "Horario especial",
+                            selected = !pendingIsUnavailable,
+                            selectedColor = BrandBlue,
+                            onClick = { onTypeChange(false) },
+                        )
+                    }
+                }
+
+                // Horas (solo si horario especial)
+                AnimatedVisibility(visible = !pendingIsUnavailable) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        TimeField(
+                            modifier = Modifier.weight(1f),
+                            label = "Desde",
+                            value = pendingStart,
+                            onValueChange = onStartChange,
+                        )
+                        TimeField(
+                            modifier = Modifier.weight(1f),
+                            label = "Hasta",
+                            value = pendingEnd,
+                            onValueChange = onEndChange,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = pendingDate.isNotBlank(),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = BrandBlue),
+            ) {
+                Text("Agregar", color = White, fontWeight = FontWeight.Bold)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar", color = TextSecondary)
+            }
+        },
+    )
+}
+
+@Composable
+private fun TypeChip(
+    modifier: Modifier = Modifier,
+    label: String,
+    selected: Boolean,
+    selectedColor: Color,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .border(
+                width = 1.5.dp,
+                color = if (selected) selectedColor else BorderSoft,
+                shape = RoundedCornerShape(10.dp),
+            )
+            .background(if (selected) selectedColor.copy(alpha = 0.08f) else White)
+            .clickable { onClick() }
+            .padding(vertical = 10.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+            color = if (selected) selectedColor else InactiveSoft,
+        )
+    }
+}
+
+@Composable
+private fun AvailabilityHeader(onBack: () -> Unit) {
+    val infiniteTransition = rememberInfiniteTransition(label = "availability_header")
+
+    val shimmerOffset by infiniteTransition.animateFloat(
+        initialValue = -260f,
+        targetValue = 620f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3200, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "shimmer",
+    )
+
+    val badgeScale by infiniteTransition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.035f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "badge_scale",
+    )
+
+    val entranceVisible = remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { entranceVisible.value = true }
+
+    AnimatedVisibility(
+        visible = entranceVisible.value,
+        enter = fadeIn(animationSpec = tween(500)) +
+                slideInVertically(
+                    initialOffsetY = { -it / 3 },
+                    animationSpec = tween(600, easing = FastOutSlowInEasing),
+                ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(140.dp)
+                .clip(RoundedCornerShape(bottomStart = 26.dp, bottomEnd = 26.dp))
+                .background(BrandBlue)
+        ) {
+            // Shimmer
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .width(140.dp)
+                    .offset(x = shimmerOffset.dp)
+                    .graphicsLayer {
+                        rotationZ = -18f
+                        alpha = 0.16f
+                    }
+                    .background(
+                        Brush.linearGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                White.copy(alpha = 0.45f),
+                                Color.Transparent,
+                            )
+                        )
+                    )
+            )
+
+            // Back + Logo
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(start = 20.dp, top = 42.dp)
+                    .graphicsLayer { scaleX = badgeScale; scaleY = badgeScale }
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(White.copy(alpha = 0.14f))
+                    .border(
+                        width = 1.dp,
+                        color = White.copy(alpha = 0.16f),
+                        shape = RoundedCornerShape(999.dp),
+                    )
+                    .padding(horizontal = 12.dp, vertical = 9.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(White.copy(alpha = 0.14f))
+                        .clickable { onBack() },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = TablerIcons.ArrowLeft,
+                        contentDescription = "Volver",
+                        tint = White,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("Servi", color = White, fontSize = 28.sp, fontWeight = FontWeight.ExtraBold)
+                    Text("Ya", color = BrandRed, fontSize = 28.sp, fontWeight = FontWeight.ExtraBold)
+                }
+            }
+
+            // Badge derecho
+            Text(
+                text = "DISPONIBILIDAD",
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(end = 20.dp, top = 42.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(White.copy(alpha = 0.14f))
+                    .border(
+                        width = 1.dp,
+                        color = White.copy(alpha = 0.16f),
+                        shape = RoundedCornerShape(999.dp),
+                    )
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                color = White,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/navigation/WorkerNavGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/example/seviya/feature/worker/navigation/WorkerNavGraph.kt
@@ -43,6 +43,7 @@ import com.example.shared.presentation.calendar.CalendarUserRole
 import com.example.shared.presentation.calendar.MonthlyCalendarViewModel
 import com.example.seviya.core.navigation.TravelTimeConfig
 import com.example.seviya.feature.worker.WorkerAlertsScreen
+import com.example.seviya.feature.worker.WorkerAvailabilityScreen
 import com.example.seviya.core.navigation.ProfessionalProfile
 
 fun NavGraphBuilder.workerNavGraph(
@@ -273,9 +274,9 @@ fun NavGraphBuilder.workerNavGraph(
   }
 
   composable<WorkerSchedule> {
-    FeaturePlaceholder(
-        title = "Horario del trabajador",
-        subtitle = "Aquí irá la configuración de días laborales, zonas y disponibilidad.",
+    WorkerAvailabilityScreen(
+        workerId = currentWorkerId,
+        onBack = { navController.popBackStack() },
     )
   }
 

--- a/shared/src/commonMain/kotlin/com/example/shared/di/modules/DataModule.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/di/modules/DataModule.kt
@@ -138,6 +138,10 @@ val dataModule = module {
   single<IRemoteAuthDataSource> { RemoteAuthDataSource() }
   single<IAuthRepository> { AuthRepository(get()) }
 
+  // Schedule
+  single<com.example.shared.data.remote.Schedule.IRemoteScheduleDataSource> { com.example.shared.data.remote.Schedule.RemoteScheduleDataSource() }
+  single<com.example.shared.data.repository.Schedule.IScheduleRepository> { com.example.shared.data.repository.Schedule.ScheduleRepository(get()) }
+
   single(named("cloudinary")) {
     HttpClient { install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } }
   }

--- a/shared/src/commonMain/kotlin/com/example/shared/di/modules/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/di/modules/PresentationModule.kt
@@ -24,6 +24,7 @@ import com.example.shared.presentation.workerDailyAppointments.WorkerDailyAppoin
 import com.example.shared.presentation.workerDashboard.WorkerDashboardViewModel
 import com.example.shared.presentation.workerStartAppointmentOtp.WorkerStartAppointmentOtpViewModel
 import com.example.shared.presentation.workerToClientReview.WorkerToClientReviewViewModel
+import com.example.shared.presentation.workerAvailability.WorkerAvailabilityViewModel
 import com.example.shared.presentation.workerTravelTime.WorkerTravelTimeViewModel
 import com.example.shared.presentation.workersList.WorkersListViewModel
 import com.example.shared.presentation.notifications.NotificationsViewModel
@@ -56,6 +57,7 @@ val presentationModule = module {
   factory { ClientLocationCatalogViewModel(get()) }
   factory { WorkerCategoriesViewModel(get(), get()) }
   factory { WorkerTravelTimeViewModel(get()) }
+  factory { WorkerAvailabilityViewModel(get()) }
   factory { WorkerToClientReviewViewModel(get(), get(), get()) }
   factory { ClientToWorkerReviewViewModel(get(), get(), get()) }
   factory { NotificationsViewModel(get()) }

--- a/shared/src/commonMain/kotlin/com/example/shared/domain/entity/Schedule.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/domain/entity/Schedule.kt
@@ -7,6 +7,6 @@ data class Schedule(
     val dayKey: String = "",
     val dayNumber: Int = 0,
     val enabled: Boolean = false,
-    val timeBlocks: List<String> = emptyList(),
-    val updatedAt: Long = 0L,
+    val timeBlocks: List<TimeBlock> = emptyList(),
+    val updatedAt: Long? = null,
 )

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityUiState.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityUiState.kt
@@ -1,0 +1,44 @@
+package com.example.shared.presentation.workerAvailability
+
+data class DayUiItem(
+    val dayKey: String,
+    val label: String,
+    val dayNumber: Int,
+    val enabled: Boolean = false,
+    val startTime: String = "08:00",
+    val endTime: String = "17:00",
+)
+
+data class ExceptionUiItem(
+    val date: String,
+    val displayDate: String,
+    val isUnavailable: Boolean,
+    val startTime: String = "",
+    val endTime: String = "",
+)
+
+data class WorkerAvailabilityUiState(
+    val isLoading: Boolean = true,
+    val days: List<DayUiItem> = defaultDays(),
+    val exceptions: List<ExceptionUiItem> = emptyList(),
+    val isSaving: Boolean = false,
+    val saveSuccess: Boolean = false,
+    val errorMessage: String? = null,
+    val showExceptionDialog: Boolean = false,
+    val pendingDate: String = "",
+    val pendingIsUnavailable: Boolean = true,
+    val pendingStart: String = "09:00",
+    val pendingEnd: String = "12:00",
+) {
+    companion object {
+        fun defaultDays() = listOf(
+            DayUiItem("monday",    "Lunes",      1),
+            DayUiItem("tuesday",   "Martes",     2),
+            DayUiItem("wednesday", "Miércoles",  3),
+            DayUiItem("thursday",  "Jueves",     4),
+            DayUiItem("friday",    "Viernes",    5),
+            DayUiItem("saturday",  "Sábado",     6),
+            DayUiItem("sunday",    "Domingo",    7),
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityUiState.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityUiState.kt
@@ -5,40 +5,30 @@ data class DayUiItem(
     val label: String,
     val dayNumber: Int,
     val enabled: Boolean = false,
-    val startTime: String = "08:00",
-    val endTime: String = "17:00",
+    val timeBlocks: List<TimeBlockUi> = listOf(TimeBlockUi()),
 )
 
-data class ExceptionUiItem(
-    val date: String,
-    val displayDate: String,
-    val isUnavailable: Boolean,
-    val startTime: String = "",
-    val endTime: String = "",
+data class TimeBlockUi(
+    val start: String = "08:00",
+    val end: String = "17:00",
 )
 
 data class WorkerAvailabilityUiState(
     val isLoading: Boolean = true,
     val days: List<DayUiItem> = defaultDays(),
-    val exceptions: List<ExceptionUiItem> = emptyList(),
     val isSaving: Boolean = false,
     val saveSuccess: Boolean = false,
     val errorMessage: String? = null,
-    val showExceptionDialog: Boolean = false,
-    val pendingDate: String = "",
-    val pendingIsUnavailable: Boolean = true,
-    val pendingStart: String = "09:00",
-    val pendingEnd: String = "12:00",
 ) {
     companion object {
         fun defaultDays() = listOf(
-            DayUiItem("monday",    "Lunes",      1),
-            DayUiItem("tuesday",   "Martes",     2),
-            DayUiItem("wednesday", "Miércoles",  3),
-            DayUiItem("thursday",  "Jueves",     4),
-            DayUiItem("friday",    "Viernes",    5),
-            DayUiItem("saturday",  "Sábado",     6),
-            DayUiItem("sunday",    "Domingo",    7),
+            DayUiItem("monday",    "Lunes",     1),
+            DayUiItem("tuesday",   "Martes",    2),
+            DayUiItem("wednesday", "Miércoles", 3),
+            DayUiItem("thursday",  "Jueves",    4),
+            DayUiItem("friday",    "Viernes",   5),
+            DayUiItem("saturday",  "Sábado",    6),
+            DayUiItem("sunday",    "Domingo",   7),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 @OptIn(ExperimentalTime::class)
 class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository) : ViewModel() {
@@ -27,7 +25,7 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
                 .catch { e ->
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        errorMessage = e.message ?: "Error al cargar disponibilidad",
+                        errorMessage = e.message ?: "Error loading availability",
                     )
                 }
                 .collect { schedules ->
@@ -35,26 +33,22 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
                     val weeklyMap = schedules
                         .filter { it.dayKey in dayKeys }
                         .associateBy { it.dayKey }
-                    val exceptions = schedules.filter { it.dayKey !in dayKeys }
 
                     val updatedDays = WorkerAvailabilityUiState.defaultDays().map { day ->
                         val saved = weeklyMap[day.dayKey]
                         if (saved != null) {
-                            val block = saved.timeBlocks.firstOrNull()
-                            day.copy(
-                                enabled = saved.enabled,
-                                startTime = block?.start?.takeIf { it.isNotBlank() } ?: "08:00",
-                                endTime = block?.end?.takeIf { it.isNotBlank() } ?: "17:00",
-                            )
+                            val blocks = if (saved.timeBlocks.isNotEmpty()) {
+                                saved.timeBlocks.map { TimeBlockUi(start = it.start, end = it.end) }
+                            } else {
+                                listOf(TimeBlockUi())
+                            }
+                            day.copy(enabled = saved.enabled, timeBlocks = blocks)
                         } else day
                     }
-
-                    val updatedExceptions = exceptions.map { it.toExceptionUiItem() }
 
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
                         days = updatedDays,
-                        exceptions = updatedExceptions,
                     )
                 }
         }
@@ -68,98 +62,63 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
         )
     }
 
-    fun updateDayTime(dayKey: String, start: String, end: String) {
+    fun addTimeBlock(dayKey: String) {
         _uiState.value = _uiState.value.copy(
             days = _uiState.value.days.map { day ->
-                if (day.dayKey == dayKey) day.copy(startTime = start, endTime = end) else day
+                if (day.dayKey == dayKey)
+                    day.copy(timeBlocks = day.timeBlocks + TimeBlockUi())
+                else day
             }
         )
     }
 
-    fun openExceptionDialog() {
-        val today = Clock.System.now()
-            .toLocalDateTime(TimeZone.currentSystemDefault())
-            .date.toString()
+    fun removeTimeBlock(dayKey: String, index: Int) {
         _uiState.value = _uiState.value.copy(
-            showExceptionDialog = true,
-            pendingDate = today,
-            pendingIsUnavailable = true,
-            pendingStart = "09:00",
-            pendingEnd = "12:00",
+            days = _uiState.value.days.map { day ->
+                if (day.dayKey == dayKey && day.timeBlocks.size > 1)
+                    day.copy(timeBlocks = day.timeBlocks.toMutableList().also { it.removeAt(index) })
+                else day
+            }
         )
     }
 
-    fun closeExceptionDialog() {
-        _uiState.value = _uiState.value.copy(showExceptionDialog = false)
-    }
-
-    fun updatePendingDate(date: String) {
-        _uiState.value = _uiState.value.copy(pendingDate = date)
-    }
-
-    fun updatePendingType(isUnavailable: Boolean) {
-        _uiState.value = _uiState.value.copy(pendingIsUnavailable = isUnavailable)
-    }
-
-    fun updatePendingStart(start: String) {
-        _uiState.value = _uiState.value.copy(pendingStart = start)
-    }
-
-    fun updatePendingEnd(end: String) {
-        _uiState.value = _uiState.value.copy(pendingEnd = end)
-    }
-
-    fun confirmException(workerId: String) {
-        val state = _uiState.value
-        if (state.pendingDate.isBlank()) return
-        if (state.exceptions.any { it.date == state.pendingDate }) return
-
-        viewModelScope.launch {
-            val timeBlocks = if (state.pendingIsUnavailable) emptyList()
-            else listOf(TimeBlock(start = state.pendingStart, end = state.pendingEnd))
-
-            val schedule = Schedule(
-                dayKey = state.pendingDate,
-                dayNumber = -1,
-                enabled = !state.pendingIsUnavailable,
-                timeBlocks = timeBlocks,
-                updatedAt = Clock.System.now().toEpochMilliseconds(),
-
-            )
-            scheduleRepo.createOrUpdateSchedule(workerId, schedule)
-            closeExceptionDialog()
-        }
-    }
-
-    fun deleteException(workerId: String, date: String) {
-        viewModelScope.launch {
-            scheduleRepo.deleteSchedule(workerId, date)
-        }
+    fun updateTimeBlock(dayKey: String, index: Int, start: String, end: String) {
+        _uiState.value = _uiState.value.copy(
+            days = _uiState.value.days.map { day ->
+                if (day.dayKey == dayKey) {
+                    val updated = day.timeBlocks.toMutableList()
+                    if (index in updated.indices) updated[index] = TimeBlockUi(start, end)
+                    day.copy(timeBlocks = updated)
+                } else day
+            }
+        )
     }
 
     fun save(workerId: String) {
-        val days = _uiState.value.days
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isSaving = true, errorMessage = null)
             try {
-                days.forEach { day ->
-                    val timeBlocks = if (day.enabled) listOf(TimeBlock(start = day.startTime, end = day.endTime))
+                _uiState.value.days.forEach { day ->
+                    val timeBlocks = if (day.enabled)
+                        day.timeBlocks.map { TimeBlock(start = it.start, end = it.end) }
                     else emptyList()
-                    val schedule = Schedule(
-                        dayKey = day.dayKey,
-                        dayNumber = day.dayNumber,
-                        enabled = day.enabled,
-                        timeBlocks = timeBlocks,
-                        updatedAt = Clock.System.now().toEpochMilliseconds(),
 
+                    scheduleRepo.createOrUpdateSchedule(
+                        workerId,
+                        Schedule(
+                            dayKey = day.dayKey,
+                            dayNumber = day.dayNumber,
+                            enabled = day.enabled,
+                            timeBlocks = timeBlocks,
+                            updatedAt = Clock.System.now().toEpochMilliseconds(),
+                        )
                     )
-                    scheduleRepo.createOrUpdateSchedule(workerId, schedule)
                 }
                 _uiState.value = _uiState.value.copy(isSaving = false, saveSuccess = true)
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     isSaving = false,
-                    errorMessage = e.message ?: "Error al guardar",
+                    errorMessage = e.message ?: "Error saving availability",
                 )
             }
         }
@@ -172,28 +131,4 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
     fun clearError() {
         _uiState.value = _uiState.value.copy(errorMessage = null)
     }
-}
-
-private fun Schedule.toExceptionUiItem(): ExceptionUiItem {
-    val block = timeBlocks.firstOrNull()
-    return ExceptionUiItem(
-        date = dayKey,
-        displayDate = formatExceptionDate(dayKey),
-        isUnavailable = !enabled,
-        startTime = block?.start ?: "",
-        endTime = block?.end ?: "",
-    )
-}
-
-private fun formatExceptionDate(date: String): String {
-    // date format: "YYYY-MM-DD"
-    val parts = date.split("-")
-    if (parts.size != 3) return date
-    val monthNames = listOf(
-        "ene", "feb", "mar", "abr", "may", "jun",
-        "jul", "ago", "sep", "oct", "nov", "dic"
-    )
-    val month = parts[1].toIntOrNull()?.minus(1) ?: return date
-    val monthName = monthNames.getOrElse(month) { parts[1] }
-    return "${parts[2]} $monthName ${parts[0]}"
 }

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
@@ -25,7 +25,7 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
                 .catch { e ->
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        errorMessage = e.message ?: "Error loading availability",
+                        errorMessage = e.message ?: "Error al cargar la disponibilidad",
                     )
                 }
                 .collect { schedules ->
@@ -118,7 +118,7 @@ class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository)
             } catch (e: Exception) {
                 _uiState.value = _uiState.value.copy(
                     isSaving = false,
-                    errorMessage = e.message ?: "Error saving availability",
+                    errorMessage = e.message ?: "Error al guardar la disponibilidad",
                 )
             }
         }

--- a/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/example/shared/presentation/workerAvailability/WorkerAvailabilityViewModel.kt
@@ -1,0 +1,199 @@
+package com.example.shared.presentation.workerAvailability
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.shared.data.repository.Schedule.IScheduleRepository
+import com.example.shared.domain.entity.Schedule
+import com.example.shared.domain.entity.TimeBlock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+@OptIn(ExperimentalTime::class)
+class WorkerAvailabilityViewModel(private val scheduleRepo: IScheduleRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WorkerAvailabilityUiState())
+    val uiState: StateFlow<WorkerAvailabilityUiState> = _uiState.asStateFlow()
+
+    fun loadData(workerId: String) {
+        viewModelScope.launch {
+            scheduleRepo.getScheduleByUser(workerId)
+                .catch { e ->
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        errorMessage = e.message ?: "Error al cargar disponibilidad",
+                    )
+                }
+                .collect { schedules ->
+                    val dayKeys = WorkerAvailabilityUiState.defaultDays().map { it.dayKey }.toSet()
+                    val weeklyMap = schedules
+                        .filter { it.dayKey in dayKeys }
+                        .associateBy { it.dayKey }
+                    val exceptions = schedules.filter { it.dayKey !in dayKeys }
+
+                    val updatedDays = WorkerAvailabilityUiState.defaultDays().map { day ->
+                        val saved = weeklyMap[day.dayKey]
+                        if (saved != null) {
+                            val block = saved.timeBlocks.firstOrNull()
+                            day.copy(
+                                enabled = saved.enabled,
+                                startTime = block?.start?.takeIf { it.isNotBlank() } ?: "08:00",
+                                endTime = block?.end?.takeIf { it.isNotBlank() } ?: "17:00",
+                            )
+                        } else day
+                    }
+
+                    val updatedExceptions = exceptions.map { it.toExceptionUiItem() }
+
+                    _uiState.value = _uiState.value.copy(
+                        isLoading = false,
+                        days = updatedDays,
+                        exceptions = updatedExceptions,
+                    )
+                }
+        }
+    }
+
+    fun toggleDay(dayKey: String) {
+        _uiState.value = _uiState.value.copy(
+            days = _uiState.value.days.map { day ->
+                if (day.dayKey == dayKey) day.copy(enabled = !day.enabled) else day
+            }
+        )
+    }
+
+    fun updateDayTime(dayKey: String, start: String, end: String) {
+        _uiState.value = _uiState.value.copy(
+            days = _uiState.value.days.map { day ->
+                if (day.dayKey == dayKey) day.copy(startTime = start, endTime = end) else day
+            }
+        )
+    }
+
+    fun openExceptionDialog() {
+        val today = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .date.toString()
+        _uiState.value = _uiState.value.copy(
+            showExceptionDialog = true,
+            pendingDate = today,
+            pendingIsUnavailable = true,
+            pendingStart = "09:00",
+            pendingEnd = "12:00",
+        )
+    }
+
+    fun closeExceptionDialog() {
+        _uiState.value = _uiState.value.copy(showExceptionDialog = false)
+    }
+
+    fun updatePendingDate(date: String) {
+        _uiState.value = _uiState.value.copy(pendingDate = date)
+    }
+
+    fun updatePendingType(isUnavailable: Boolean) {
+        _uiState.value = _uiState.value.copy(pendingIsUnavailable = isUnavailable)
+    }
+
+    fun updatePendingStart(start: String) {
+        _uiState.value = _uiState.value.copy(pendingStart = start)
+    }
+
+    fun updatePendingEnd(end: String) {
+        _uiState.value = _uiState.value.copy(pendingEnd = end)
+    }
+
+    fun confirmException(workerId: String) {
+        val state = _uiState.value
+        if (state.pendingDate.isBlank()) return
+        if (state.exceptions.any { it.date == state.pendingDate }) return
+
+        viewModelScope.launch {
+            val timeBlocks = if (state.pendingIsUnavailable) emptyList()
+            else listOf(TimeBlock(start = state.pendingStart, end = state.pendingEnd))
+
+            val schedule = Schedule(
+                dayKey = state.pendingDate,
+                dayNumber = -1,
+                enabled = !state.pendingIsUnavailable,
+                timeBlocks = timeBlocks,
+                updatedAt = Clock.System.now().toEpochMilliseconds(),
+
+            )
+            scheduleRepo.createOrUpdateSchedule(workerId, schedule)
+            closeExceptionDialog()
+        }
+    }
+
+    fun deleteException(workerId: String, date: String) {
+        viewModelScope.launch {
+            scheduleRepo.deleteSchedule(workerId, date)
+        }
+    }
+
+    fun save(workerId: String) {
+        val days = _uiState.value.days
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, errorMessage = null)
+            try {
+                days.forEach { day ->
+                    val timeBlocks = if (day.enabled) listOf(TimeBlock(start = day.startTime, end = day.endTime))
+                    else emptyList()
+                    val schedule = Schedule(
+                        dayKey = day.dayKey,
+                        dayNumber = day.dayNumber,
+                        enabled = day.enabled,
+                        timeBlocks = timeBlocks,
+                        updatedAt = Clock.System.now().toEpochMilliseconds(),
+
+                    )
+                    scheduleRepo.createOrUpdateSchedule(workerId, schedule)
+                }
+                _uiState.value = _uiState.value.copy(isSaving = false, saveSuccess = true)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSaving = false,
+                    errorMessage = e.message ?: "Error al guardar",
+                )
+            }
+        }
+    }
+
+    fun clearSaveSuccess() {
+        _uiState.value = _uiState.value.copy(saveSuccess = false)
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+}
+
+private fun Schedule.toExceptionUiItem(): ExceptionUiItem {
+    val block = timeBlocks.firstOrNull()
+    return ExceptionUiItem(
+        date = dayKey,
+        displayDate = formatExceptionDate(dayKey),
+        isUnavailable = !enabled,
+        startTime = block?.start ?: "",
+        endTime = block?.end ?: "",
+    )
+}
+
+private fun formatExceptionDate(date: String): String {
+    // date format: "YYYY-MM-DD"
+    val parts = date.split("-")
+    if (parts.size != 3) return date
+    val monthNames = listOf(
+        "ene", "feb", "mar", "abr", "may", "jun",
+        "jul", "ago", "sep", "oct", "nov", "dic"
+    )
+    val month = parts[1].toIntOrNull()?.minus(1) ?: return date
+    val monthName = monthNames.getOrElse(month) { parts[1] }
+    return "${parts[2]} $monthName ${parts[0]}"
+}


### PR DESCRIPTION
 - Add WorkerAvailabilityScreen with weekly rules (7 days with toggle + multiple time ranges per day)
  - Add WorkerAvailabilityViewModel and WorkerAvailabilityUiState in shared module
  - Register IScheduleRepository and WorkerAvailabilityViewModel in Koin (DataModule, PresentationModule)
  - Fix Schedule.timeBlocks to List<TimeBlock> to match actual Firestore data structure
  - Fix Schedule.updatedAt to nullable for compatibility with existing documents
  - Replace WorkerSchedule FeaturePlaceholder with real screen in WorkerNavGraph
  - Each day supports multiple time blocks (add/remove dynamically)